### PR TITLE
Modify around m_categories to categories

### DIFF
--- a/todo.com/cmd/database/database.go
+++ b/todo.com/cmd/database/database.go
@@ -58,21 +58,21 @@ func newDB() (*Gorm, error) {
 // migrate is to create Tables
 func (g *Gorm) migrate() error {
 	return g.AutoMigrate(
-		&models.MCategory{},
+		&models.Category{},
 		&models.MStatus{},
 		&models.User{},
 		&models.Task{},
-		&models.TaskHasMCategory{},
+		&models.TaskHasCategory{},
 	)
 }
 
 // dropTable is to delete tables
 func (g *Gorm) dropTable() error {
 	return g.Migrator().DropTable(
-		&models.MCategory{},
+		&models.Category{},
 		&models.MStatus{},
 		&models.User{},
 		&models.Task{},
-		&models.TaskHasMCategory{},
+		&models.TaskHasCategory{},
 	)
 }

--- a/todo.com/cmd/main.go
+++ b/todo.com/cmd/main.go
@@ -25,6 +25,7 @@ func main() {
 	tableOperateFlags := []string{DB_TYPE_MIGRATE, DB_TYPE_DROP}
 	if !slices.Contains(tableOperateFlags, *dbOperate) {
 		fmt.Printf("Nothing to run. Please set some option. Allowed options are '%s'\n", "-d")
+		return
 	}
 
 	if err := database.Run(*dbOperate); err != nil {

--- a/todo.com/domain/models/category.go
+++ b/todo.com/domain/models/category.go
@@ -4,16 +4,16 @@ import (
 	"time"
 )
 
-// MCategory is struct for m_categories
-type MCategory struct {
-	ID        uint32    `gorm:"type:int;primarykey"`
+// Category is struct for categories
+type Category struct {
+	ID        uint64    `gorm:"type:int;primarykey"`
 	Name      string    `gorm:"type:varchar(255);not null"`
 	ColorCode string    `gorm:"type:varchar(255);unique;not null"`
 	CreatedAt time.Time `gorm:"type:datetime(6);not null"`
 	UpdatedAt time.Time `gorm:"type:datetime(6)"`
 }
 
-// CREATE TABLE `m_categories` (
+// CREATE TABLE `categories` (
 // 	`id` int NOT NULL AUTO_INCREMENT,
 // 	`name` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
 // 	`color_code` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,

--- a/todo.com/domain/models/task_has_m_category.go
+++ b/todo.com/domain/models/task_has_m_category.go
@@ -2,24 +2,24 @@ package models
 
 import "gorm.io/gorm"
 
-// TaskHasMCategory is struct for task_has_m_categories
-type TaskHasMCategory struct {
-	MCategoryID uint32    `gorm:"not null;index:unique_task_id_m_category_id,unique"`
-	MCategory   MCategory `gorm:"constraint:OnDelete:CASCADE;"`
-	TaskID      uint64    `gorm:"not null;index:unique_task_id_m_category_id,unique"`
-	Task        Task      `gorm:"constraint:OnDelete:CASCADE;"`
+// TaskHasCategory is struct for task_has_categories
+type TaskHasCategory struct {
+	CategoryID uint64   `gorm:"not null;index:unique_task_id_category_id,unique"`
+	Category   Category `gorm:"constraint:OnDelete:CASCADE;"`
+	TaskID     uint64   `gorm:"not null;index:unique_task_id_category_id,unique"`
+	Task       Task     `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
-// CREATE TABLE `task_has_m_categories` (
-// 	`m_category_id` int NOT NULL,
+// CREATE TABLE `task_has_categories` (
+// 	`category_id` bigint NOT NULL,
 // 	`task_id` bigint unsigned NOT NULL,
-// 	UNIQUE KEY `unique_task_id_m_category_id` (`m_category_id`,`task_id`),
-// 	KEY `fk_task_has_m_categories_task` (`task_id`),
-// 	CONSTRAINT `fk_task_has_m_categories_m_category` FOREIGN KEY (`m_category_id`) REFERENCES `m_categories` (`id`) ON DELETE CASCADE,
-// 	CONSTRAINT `fk_task_has_m_categories_task` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON DELETE CASCADE
+// 	UNIQUE KEY `unique_task_id_category_id` (`category_id`,`task_id`),
+// 	KEY `fk_task_has_categories_task` (`task_id`),
+// 	CONSTRAINT `fk_task_has_categories_category` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE CASCADE,
+// 	CONSTRAINT `fk_task_has_categories_task` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON DELETE CASCADE
 //   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
 
-// AddMCategoryIDIndexToTAskHasMCategory add index to m_category_id
+// AddCategoryIDIndexToTAskHasCategory add index to category_id
 // Those struct will create above.
 // Only task_id's index is created
 // > https://stackoverflow.com/questions/9474954/mysql-show-create-table-shows-extra-entry-with-key
@@ -31,6 +31,6 @@ type TaskHasMCategory struct {
 // > https://zenn.dev/awonosuke/articles/96b3d580860e4d
 // >> MySQLでは勝手にインデックスが作成されると述べたが、外部キー制約の宣言の前に、
 // >> 対象カラムを含む複合キーを宣言することで、インデックスの自動生成は回避することができる模様
-func AddMCategoryIDIndexToTAskHasMCategory(db *gorm.DB) error {
-	return db.Exec("ALTER TABLE task_has_m_categories ADD INDEX fk_task_has_m_categories_m_category(m_category_id);").Error
+func AddCategoryIDIndexToTAskHasCategory(db *gorm.DB) error {
+	return db.Exec("ALTER TABLE task_has_categories ADD INDEX fk_task_has_categories_category(category_id);").Error
 }


### PR DESCRIPTION
# Overview
Change m_categories to categories table name because the categories are created by user, which means not be appropriate  name. 

# What I did
- change all name from m_categories to categories
- change all name from m_category to category